### PR TITLE
aiohttp version with phone support

### DIFF
--- a/homeassistant/components/aussie_broadband/__init__.py
+++ b/homeassistant/components/aussie_broadband/__init__.py
@@ -1,13 +1,14 @@
 """The Aussie Broadband integration."""
 from __future__ import annotations
 
-from aussiebb import AussieBB, AuthenticationException
+from aussiebb.asyncio import AussieBB, AuthenticationException
 import requests
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
 
@@ -17,20 +18,23 @@ PLATFORMS = ["sensor"]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Aussie Broadband from a config entry."""
 
-    def create_client():
-        try:
-            return AussieBB(entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD])
-        except AuthenticationException as exc:
-            raise ConfigEntryAuthFailed() from exc
-        except (
-            requests.exceptions.ConnectionError,
-            requests.exceptions.HTTPError,
-        ) as exc:
-            raise ConfigEntryNotReady() from exc
+    try:
+        client = AussieBB(
+            entry.data[CONF_USERNAME],
+            entry.data[CONF_PASSWORD],
+            async_get_clientsession(hass),
+        )
+        await client.login()
 
-    hass.data.setdefault(DOMAIN, {})[
-        entry.entry_id
-    ] = await hass.async_add_executor_job(create_client)
+    except AuthenticationException as exc:
+        raise ConfigEntryAuthFailed() from exc
+    except (
+        requests.exceptions.ConnectionError,
+        requests.exceptions.HTTPError,
+    ) as exc:
+        raise ConfigEntryNotReady() from exc
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = client
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
     return True

--- a/homeassistant/components/aussie_broadband/__init__.py
+++ b/homeassistant/components/aussie_broadband/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN
+from .const import CONF_SERVICES, DOMAIN
 
 PLATFORMS = ["sensor"]
 
@@ -24,7 +24,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.data[CONF_PASSWORD],
             async_get_clientsession(hass),
         )
-        await client.login()
+        # await client.login()
+        all_services = await client.get_services()
 
     except AuthenticationException as exc:
         raise ConfigEntryAuthFailed() from exc
@@ -34,7 +35,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     ) as exc:
         raise ConfigEntryNotReady() from exc
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = client
+    services = next(
+        s for s in all_services if s["service_id"] in entry.data[CONF_SERVICES]
+    )
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        client: client,
+        services: services,
+    }
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
     return True

--- a/homeassistant/components/aussie_broadband/__init__.py
+++ b/homeassistant/components/aussie_broadband/__init__.py
@@ -18,13 +18,14 @@ PLATFORMS = ["sensor"]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Aussie Broadband from a config entry."""
 
+    # Login to the Aussie Broadband API and retrieve the current service list
     try:
         client = AussieBB(
             entry.data[CONF_USERNAME],
             entry.data[CONF_PASSWORD],
             async_get_clientsession(hass),
         )
-        # await client.login()  # Will be optional later
+        await client.login()
         all_services = await client.get_services()
 
     except AuthenticationException as exc:
@@ -32,10 +33,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except ClientError as exc:
         raise ConfigEntryNotReady() from exc
 
+    # Filter the service list to those that are enabled in options
     services = [
         s for s in all_services if str(s["service_id"]) in entry.options[CONF_SERVICES]
     ]
 
+    # Setup the integration
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "client": client,
         "services": services,
@@ -52,7 +55,7 @@ async def update_listener(hass: HomeAssistant, entry: ConfigEntry):
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a config entry."""
+    """Unload the config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/homeassistant/components/aussie_broadband/__init__.py
+++ b/homeassistant/components/aussie_broadband/__init__.py
@@ -44,8 +44,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "services": services,
     }
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(update_listener))
 
     return True
+
+
+async def update_listener(hass: HomeAssistant, entry: ConfigEntry):
+    """Reload to update options."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/aussie_broadband/__init__.py
+++ b/homeassistant/components/aussie_broadband/__init__.py
@@ -24,7 +24,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.data[CONF_PASSWORD],
             async_get_clientsession(hass),
         )
-        # await client.login()
+        await client.login()  # Will be optional later
         all_services = await client.get_services()
 
     except AuthenticationException as exc:
@@ -35,13 +35,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     ) as exc:
         raise ConfigEntryNotReady() from exc
 
-    services = next(
-        s for s in all_services if s["service_id"] in entry.data[CONF_SERVICES]
-    )
+    services = [
+        s for s in all_services if str(s["service_id"]) in entry.options[CONF_SERVICES]
+    ]
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        client: client,
-        services: services,
+        "client": client,
+        "services": services,
     }
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 

--- a/homeassistant/components/aussie_broadband/__init__.py
+++ b/homeassistant/components/aussie_broadband/__init__.py
@@ -1,8 +1,8 @@
 """The Aussie Broadband integration."""
 from __future__ import annotations
 
+from aiohttp import ClientError
 from aussiebb.asyncio import AussieBB, AuthenticationException
-import requests
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -24,15 +24,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.data[CONF_PASSWORD],
             async_get_clientsession(hass),
         )
-        await client.login()  # Will be optional later
+        # await client.login()  # Will be optional later
         all_services = await client.get_services()
 
     except AuthenticationException as exc:
         raise ConfigEntryAuthFailed() from exc
-    except (
-        requests.exceptions.ConnectionError,
-        requests.exceptions.HTTPError,
-    ) as exc:
+    except ClientError as exc:
         raise ConfigEntryNotReady() from exc
 
     services = [

--- a/homeassistant/components/aussie_broadband/config_flow.py
+++ b/homeassistant/components/aussie_broadband/config_flow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from aiohttp import ClientError
 from aussiebb.asyncio import AussieBB, AuthenticationException
 import voluptuous as vol
 
@@ -20,6 +21,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Aussie Broadband."""
 
     VERSION = 1
+    _reauth_username: str
 
     def __init__(self):
         """Initialize the config flow."""
@@ -38,7 +40,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             return await self.client.login()
         except AuthenticationException:
-            return False
+            return {"base": "invalid_auth"}
+        except ClientError:
+            return {"base": "cannot_connect"}
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -46,7 +50,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         errors = None
         if user_input is not None:
-            if await self.auth(user_input):
+            auth = await self.auth(user_input)
+            if auth is True:
                 await self.async_set_unique_id(user_input[CONF_USERNAME])
                 self._abort_if_unique_id_configured()
 
@@ -57,16 +62,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     return self.async_abort(reason="no_services_found")
 
                 if len(self.services) == 1:
-                    # self.options[CONF_SERVICES] = [str(self.services[0][SERVICE_ID])]
                     return self.async_create_entry(
                         title=self.data[CONF_USERNAME],
                         data=self.data,
                         options={CONF_SERVICES: [str(self.services[0][SERVICE_ID])]},
                     )
 
-                # account has more than one service, select service to add
+                # Account has more than one service, select service to add
                 return await self.async_step_service()
-            errors = {"base": "invalid_auth"}
+            errors = auth
 
         return self.async_show_form(
             step_id="user",
@@ -84,7 +88,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle the optional service selection step."""
         if user_input is not None:
-            # self.options[CONF_SERVICES] = user_input[CONF_SERVICES]
             return self.async_create_entry(
                 title=self.data[CONF_USERNAME], data=self.data, options=user_input
             )
@@ -107,17 +110,17 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle reauth."""
         errors = None
         if user_input and user_input.get(CONF_USERNAME):
-            self.username = user_input[CONF_USERNAME]
-            self.context["title_placeholders"] = {CONF_USERNAME: self.username}
+            self._reauth_username = user_input[CONF_USERNAME]
 
         elif user_input and user_input.get(CONF_PASSWORD):
             data = {
-                CONF_USERNAME: self.username,
+                CONF_USERNAME: self._reauth_username,
                 CONF_PASSWORD: user_input[CONF_PASSWORD],
             }
 
-            if await self.auth(data):
-                entry = await self.async_set_unique_id(self.username)
+            auth = await self.auth(data)
+            if auth is True:
+                entry = await self.async_set_unique_id(self._reauth_username)
                 if entry:
                     self.hass.config_entries.async_update_entry(
                         entry,
@@ -125,12 +128,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     )
                     await self.hass.config_entries.async_reload(entry.entry_id)
                     return self.async_abort(reason="reauth_successful")
-                return self.async_create_entry(title=self.username, data=data)
-
-            errors = {"base": "invalid_auth"}
+                return self.async_create_entry(title=self._reauth_username, data=data)
+            errors = auth
 
         return self.async_show_form(
             step_id="reauth",
+            description_placeholders={"username": self._reauth_username},
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_PASSWORD): str,
@@ -159,10 +162,19 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         """Manage the options."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
-            # await self.hass.config_entries.async_reload(self.config_entry.entry_id)
 
+        if (
+            DOMAIN not in self.hass.data
+            or self.config_entry.entry_id not in self.hass.data[DOMAIN]
+        ):
+            return self.async_abort(reason="unknown")
         data = self.hass.data[DOMAIN][self.config_entry.entry_id]
-        services = await data["client"].get_services()
+        try:
+            services = await data["client"].get_services()
+        except AuthenticationException:
+            return self.async_abort(reason="invalid_auth")
+        except ClientError:
+            return self.async_abort(reason="cannot_connect")
         service_options = {str(s[SERVICE_ID]): s["description"] for s in services}
         return self.async_show_form(
             step_id="init",

--- a/homeassistant/components/aussie_broadband/config_flow.py
+++ b/homeassistant/components/aussie_broadband/config_flow.py
@@ -9,8 +9,9 @@ import voluptuous as vol
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlow as ConfigFlowBase
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.data_entry_flow import FlowResult
+import homeassistant.helpers.config_validation as cv
 
-from .const import CONF_SERVICE_ID, DOMAIN
+from .const import CONF_SERVICES, DOMAIN
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
@@ -51,14 +52,12 @@ class ConfigFlow(ConfigFlowBase, domain=DOMAIN):
 
         if self.client is not None:
             self.data.update(user_input)
-            self.services = await self.hass.async_add_executor_job(
-                self.client.get_services
-            )
+            self.services = await self.client.get_services()
             if len(self.services) == 0:
                 return self.async_abort(reason="no_services_found")
 
             if len(self.services) == 1:
-                return await self.create_entry(self.services[0])
+                return await self.create_entry(self.services)
 
             # account has more than one service, select service to add
             return await self.async_step_service()
@@ -75,18 +74,13 @@ class ConfigFlow(ConfigFlowBase, domain=DOMAIN):
         """Handle the service selection step."""
 
         if user_input is not None:
-            service = next(
-                s
-                for s in self.services
-                if s["service_id"] == user_input[CONF_SERVICE_ID]
-            )
-            return await self.create_entry(service)
+            return await self.create_entry(user_input[CONF_SERVICES])
 
         service_options = {s["service_id"]: s["description"] for s in self.services}
         return self.async_show_form(
             step_id="service",
             data_schema=vol.Schema(
-                {vol.Required(CONF_SERVICE_ID): vol.In(service_options)}
+                {vol.Required(CONF_SERVICES): cv.multi_select(service_options)}
             ),
         )
 
@@ -96,17 +90,15 @@ class ConfigFlow(ConfigFlowBase, domain=DOMAIN):
         """Handle reauth."""
         return await self.async_step_user(user_input)
 
-    async def create_entry(self, service):
+    async def create_entry(self, services):
         """Create entry for a service."""
-        self.data[CONF_SERVICE_ID] = service["service_id"]
+        self.data[CONF_SERVICES] = services
 
-        entry = await self.async_set_unique_id(self.data[CONF_SERVICE_ID])
+        entry = await self.async_set_unique_id(self.data[CONF_USERNAME])
         if self.source == SOURCE_REAUTH:
-            self.hass.config_entries.async_update_entry(
-                entry, title=service["description"], data=self.data
-            )
+            self.hass.config_entries.async_update_entry(entry, data=self.data)
             await self.hass.config_entries.async_reload(entry.entry_id)
             return self.async_abort(reason="reauth_successful")
 
         self._abort_if_unique_id_configured()
-        return self.async_create_entry(title=service["description"], data=self.data)
+        return self.async_create_entry(title=self.data[CONF_USERNAME], data=self.data)

--- a/homeassistant/components/aussie_broadband/config_flow.py
+++ b/homeassistant/components/aussie_broadband/config_flow.py
@@ -7,13 +7,13 @@ from aussiebb.asyncio import AussieBB, AuthenticationException
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 
-from .const import CONF_SERVICES, DOMAIN, SERVICE_ID
+from .const import CONF_SERVICES, DEFAULT_UPDATE_INTERVAL, DOMAIN, SERVICE_ID
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -28,7 +28,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.services = None
         self.client = None
 
-    async def auth(self, user_input: dict[str]):
+    async def auth(self, user_input: dict[str, str]):
         """Reusable Auth Helper."""
         errors = {}
         try:
@@ -100,7 +100,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 {
                     vol.Required(
                         CONF_SERVICES, default=list(service_options.keys())
-                    ): cv.multi_select(service_options)
+                    ): cv.multi_select(service_options),
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1)),
                 }
             ),
         )
@@ -123,12 +126,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             if self.client is not None:
                 entry = await self.async_set_unique_id(self.username)
-                self.hass.config_entries.async_update_entry(
-                    entry,
-                    data=data,
-                )
-                await self.hass.config_entries.async_reload(entry.entry_id)
-                return self.async_abort(reason="reauth_successful")
+                if entry:
+                    self.hass.config_entries.async_update_entry(
+                        entry,
+                        data=data,
+                    )
+                    await self.hass.config_entries.async_reload(entry.entry_id)
+                    return self.async_abort(reason="reauth_successful")
+                return self.async_create_entry(title=self.username, data=data)
 
         return self.async_show_form(
             step_id="reauth",
@@ -172,7 +177,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Required(
                         CONF_SERVICES,
                         default=self.config_entry.options.get(CONF_SERVICES),
-                    ): cv.multi_select(service_options)
+                    ): cv.multi_select(service_options),
+                    vol.Optional(
+                        CONF_SCAN_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1)),
                 }
             ),
         )

--- a/homeassistant/components/aussie_broadband/config_flow.py
+++ b/homeassistant/components/aussie_broadband/config_flow.py
@@ -100,10 +100,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 {
                     vol.Required(
                         CONF_SERVICES, default=list(service_options.keys())
-                    ): cv.multi_select(service_options),
-                    vol.Optional(
-                        CONF_SCAN_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
-                    ): vol.All(vol.Coerce(int), vol.Range(min=1)),
+                    ): cv.multi_select(service_options)
                 }
             ),
         )
@@ -179,7 +176,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         default=self.config_entry.options.get(CONF_SERVICES),
                     ): cv.multi_select(service_options),
                     vol.Optional(
-                        CONF_SCAN_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
+                        CONF_SCAN_INTERVAL,
+                        default=self.config_entry.options.get(
+                            CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL
+                        ),
                     ): vol.All(vol.Coerce(int), vol.Range(min=1)),
                 }
             ),

--- a/homeassistant/components/aussie_broadband/config_flow.py
+++ b/homeassistant/components/aussie_broadband/config_flow.py
@@ -10,6 +10,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 
 from .const import CONF_SERVICES, DOMAIN, SERVICE_ID
@@ -22,52 +23,61 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self):
         """Initialize the config flow."""
-        self.data = {}
-        self.options = {}
+        self.data: dict = {}
+        self.options: dict = {CONF_SERVICES: []}
         self.services = None
         self.client = None
+
+    async def auth(self, user_input: dict[str]):
+        """Reusable Auth Helper."""
+        errors = {}
+        try:
+            self.client = AussieBB(
+                user_input[CONF_USERNAME],
+                user_input[CONF_PASSWORD],
+                async_get_clientsession(self.hass),
+            )
+            await self.client.login()
+        except AuthenticationException:
+            errors["base"] = "invalid_auth"
+
+        return errors
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the initial step."""
         errors = {}
-        default_username = None
-        default_password = None
         if user_input is not None:
-            try:
-                self.client = await self.hass.async_add_executor_job(
-                    AussieBB, user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
-                )
-                await self.client.login()
-            except AuthenticationException:
-                errors["base"] = "invalid_auth"
+            errors = await self.auth(user_input)
 
             if self.client is not None:
-                self.data.update(user_input)
+                await self.async_set_unique_id(user_input[CONF_USERNAME])
+                self._abort_if_unique_id_configured()
+
+                self.data = user_input
                 self.services = await self.client.get_services()
+
                 if len(self.services) == 0:
                     return self.async_abort(reason="no_services_found")
 
                 if len(self.services) == 1:
-                    return await self.create_entry(self.services)
+                    # self.options[CONF_SERVICES] = [str(self.services[0][SERVICE_ID])]
+                    return self.async_create_entry(
+                        title=self.data[CONF_USERNAME],
+                        data=self.data,
+                        options={CONF_SERVICES: [str(self.services[0][SERVICE_ID])]},
+                    )
 
                 # account has more than one service, select service to add
-                if (
-                    self.source == config_entries.SOURCE_REAUTH
-                    and CONF_SERVICES in user_input
-                ):
-                    return await self.create_entry(user_input)
                 return await self.async_step_service()
-            default_username = user_input.get(CONF_USERNAME)
-            default_password = user_input.get(CONF_PASSWORD)
 
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_USERNAME, default_username): str,
-                    vol.Required(CONF_PASSWORD, default_password): str,
+                    vol.Required(CONF_USERNAME): str,
+                    vol.Required(CONF_PASSWORD): str,
                 }
             ),
             errors=errors,
@@ -76,10 +86,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_service(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the service selection step."""
-        print(user_input)
+        """Handle the optional service selection step."""
         if user_input is not None:
-            return await self.create_entry(user_input[CONF_SERVICES])
+            # self.options[CONF_SERVICES] = user_input[CONF_SERVICES]
+            return self.async_create_entry(
+                title=self.data[CONF_USERNAME], data=self.data, options=user_input
+            )
 
         service_options = {str(s[SERVICE_ID]): s["description"] for s in self.services}
         return self.async_show_form(
@@ -97,21 +109,36 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle reauth."""
-        return await self.async_step_user(user_input)
+        errors = {}
+        if user_input and user_input.get(CONF_USERNAME):
+            self.username = user_input[CONF_USERNAME]
+            self.context["title_placeholders"] = {CONF_USERNAME: self.username}
 
-    async def create_entry(self, services):
-        """Create entry for a service."""
-        self.data[CONF_SERVICES] = services
+        elif user_input and user_input.get(CONF_PASSWORD):
+            data = {
+                CONF_USERNAME: self.username,
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+            }
+            errors = await self.auth(data)
 
-        entry = await self.async_set_unique_id(self.data[CONF_USERNAME])
+            if self.client is not None:
+                entry = await self.async_set_unique_id(self.username)
+                self.hass.config_entries.async_update_entry(
+                    entry,
+                    data=data,
+                )
+                await self.hass.config_entries.async_reload(entry.entry_id)
+                return self.async_abort(reason="reauth_successful")
 
-        if self.source == config_entries.SOURCE_REAUTH:
-            self.hass.config_entries.async_update_entry(entry, data=self.data)
-            await self.hass.config_entries.async_reload(entry.entry_id)
-            return self.async_abort(reason="reauth_successful")
-
-        self._abort_if_unique_id_configured()
-        return self.async_create_entry(title=self.data[CONF_USERNAME], data=self.data)
+        return self.async_show_form(
+            step_id="reauth",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_PASSWORD): str,
+                }
+            ),
+            errors=errors,
+        )
 
     @staticmethod
     @callback
@@ -132,7 +159,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_init(self, user_input=None):
         """Manage the options."""
         if user_input is not None:
-            print(user_input)
             return self.async_create_entry(title="", data=user_input)
             # await self.hass.config_entries.async_reload(self.config_entry.entry_id)
 

--- a/homeassistant/components/aussie_broadband/config_flow.py
+++ b/homeassistant/components/aussie_broadband/config_flow.py
@@ -30,28 +30,23 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def auth(self, user_input: dict[str, str]):
         """Reusable Auth Helper."""
-        errors = {}
         try:
             self.client = AussieBB(
                 user_input[CONF_USERNAME],
                 user_input[CONF_PASSWORD],
                 async_get_clientsession(self.hass),
             )
-            await self.client.login()
+            return await self.client.login()
         except AuthenticationException:
-            errors["base"] = "invalid_auth"
-
-        return errors
+            return False
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the initial step."""
-        errors = {}
+        errors = None
         if user_input is not None:
-            errors = await self.auth(user_input)
-
-            if self.client is not None:
+            if await self.auth(user_input):
                 await self.async_set_unique_id(user_input[CONF_USERNAME])
                 self._abort_if_unique_id_configured()
 
@@ -71,6 +66,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 # account has more than one service, select service to add
                 return await self.async_step_service()
+            errors = {"base": "invalid_auth"}
 
         return self.async_show_form(
             step_id="user",
@@ -109,7 +105,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle reauth."""
-        errors = {}
+        errors = None
         if user_input and user_input.get(CONF_USERNAME):
             self.username = user_input[CONF_USERNAME]
             self.context["title_placeholders"] = {CONF_USERNAME: self.username}
@@ -119,9 +115,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_USERNAME: self.username,
                 CONF_PASSWORD: user_input[CONF_PASSWORD],
             }
-            errors = await self.auth(data)
 
-            if self.client is not None:
+            if await self.auth(data):
                 entry = await self.async_set_unique_id(self.username)
                 if entry:
                     self.hass.config_entries.async_update_entry(
@@ -131,6 +126,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     await self.hass.config_entries.async_reload(entry.entry_id)
                     return self.async_abort(reason="reauth_successful")
                 return self.async_create_entry(title=self.username, data=data)
+            errors = {"base": "invalid_auth"}
 
         return self.async_show_form(
             step_id="reauth",

--- a/homeassistant/components/aussie_broadband/config_flow.py
+++ b/homeassistant/components/aussie_broadband/config_flow.py
@@ -50,8 +50,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         errors = None
         if user_input is not None:
-            auth = await self.auth(user_input)
-            if auth is True:
+            result = await self.auth(user_input)
+            if result is True:
                 await self.async_set_unique_id(user_input[CONF_USERNAME])
                 self._abort_if_unique_id_configured()
 
@@ -70,7 +70,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 # Account has more than one service, select service to add
                 return await self.async_step_service()
-            errors = auth
+            errors = result
 
         return self.async_show_form(
             step_id="user",
@@ -118,8 +118,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_PASSWORD: user_input[CONF_PASSWORD],
             }
 
-            auth = await self.auth(data)
-            if auth is True:
+            result = await self.auth(data)
+            if result is True:
                 entry = await self.async_set_unique_id(self._reauth_username)
                 if entry:
                     self.hass.config_entries.async_update_entry(
@@ -129,7 +129,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     await self.hass.config_entries.async_reload(entry.entry_id)
                     return self.async_abort(reason="reauth_successful")
                 return self.async_create_entry(title=self._reauth_username, data=data)
-            errors = auth
+            errors = result
 
         return self.async_show_form(
             step_id="reauth",

--- a/homeassistant/components/aussie_broadband/config_flow.py
+++ b/homeassistant/components/aussie_broadband/config_flow.py
@@ -163,10 +163,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
-        if (
-            DOMAIN not in self.hass.data
-            or self.config_entry.entry_id not in self.hass.data[DOMAIN]
-        ):
+        if self.config_entry.state != config_entries.ConfigEntryState.LOADED:
             return self.async_abort(reason="unknown")
         data = self.hass.data[DOMAIN][self.config_entry.entry_id]
         try:

--- a/homeassistant/components/aussie_broadband/config_flow.py
+++ b/homeassistant/components/aussie_broadband/config_flow.py
@@ -126,6 +126,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     await self.hass.config_entries.async_reload(entry.entry_id)
                     return self.async_abort(reason="reauth_successful")
                 return self.async_create_entry(title=self.username, data=data)
+
             errors = {"base": "invalid_auth"}
 
         return self.async_show_form(

--- a/homeassistant/components/aussie_broadband/config_flow.py
+++ b/homeassistant/components/aussie_broadband/config_flow.py
@@ -3,25 +3,19 @@ from __future__ import annotations
 
 from typing import Any
 
-from aussiebb import AussieBB, AuthenticationException
+from aussiebb.asyncio import AussieBB, AuthenticationException
 import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlow as ConfigFlowBase
+from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 
-from .const import CONF_SERVICES, DOMAIN
-
-STEP_USER_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_USERNAME): str,
-        vol.Required(CONF_PASSWORD): str,
-    }
-)
+from .const import CONF_SERVICES, DOMAIN, SERVICE_ID
 
 
-class ConfigFlow(ConfigFlowBase, domain=DOMAIN):
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Aussie Broadband."""
 
     VERSION = 1
@@ -29,6 +23,7 @@ class ConfigFlow(ConfigFlowBase, domain=DOMAIN):
     def __init__(self):
         """Initialize the config flow."""
         self.data = {}
+        self.options = {}
         self.services = None
         self.client = None
 
@@ -36,35 +31,45 @@ class ConfigFlow(ConfigFlowBase, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the initial step."""
-        if user_input is None:
-            return self.async_show_form(
-                step_id="user",
-                data_schema=STEP_USER_DATA_SCHEMA,
-            )
-
         errors = {}
-        try:
-            self.client = await self.hass.async_add_executor_job(
-                AussieBB, user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
-            )
-        except AuthenticationException:
-            errors["base"] = "invalid_auth"
+        default_username = None
+        default_password = None
+        if user_input is not None:
+            try:
+                self.client = await self.hass.async_add_executor_job(
+                    AussieBB, user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+                )
+                await self.client.login()
+            except AuthenticationException:
+                errors["base"] = "invalid_auth"
 
-        if self.client is not None:
-            self.data.update(user_input)
-            self.services = await self.client.get_services()
-            if len(self.services) == 0:
-                return self.async_abort(reason="no_services_found")
+            if self.client is not None:
+                self.data.update(user_input)
+                self.services = await self.client.get_services()
+                if len(self.services) == 0:
+                    return self.async_abort(reason="no_services_found")
 
-            if len(self.services) == 1:
-                return await self.create_entry(self.services)
+                if len(self.services) == 1:
+                    return await self.create_entry(self.services)
 
-            # account has more than one service, select service to add
-            return await self.async_step_service()
+                # account has more than one service, select service to add
+                if (
+                    self.source == config_entries.SOURCE_REAUTH
+                    and CONF_SERVICES in user_input
+                ):
+                    return await self.create_entry(user_input)
+                return await self.async_step_service()
+            default_username = user_input.get(CONF_USERNAME)
+            default_password = user_input.get(CONF_PASSWORD)
 
         return self.async_show_form(
             step_id="user",
-            data_schema=STEP_USER_DATA_SCHEMA,
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_USERNAME, default_username): str,
+                    vol.Required(CONF_PASSWORD, default_password): str,
+                }
+            ),
             errors=errors,
         )
 
@@ -72,15 +77,19 @@ class ConfigFlow(ConfigFlowBase, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the service selection step."""
-
+        print(user_input)
         if user_input is not None:
             return await self.create_entry(user_input[CONF_SERVICES])
 
-        service_options = {s["service_id"]: s["description"] for s in self.services}
+        service_options = {str(s[SERVICE_ID]): s["description"] for s in self.services}
         return self.async_show_form(
             step_id="service",
             data_schema=vol.Schema(
-                {vol.Required(CONF_SERVICES): cv.multi_select(service_options)}
+                {
+                    vol.Required(
+                        CONF_SERVICES, default=list(service_options.keys())
+                    ): cv.multi_select(service_options)
+                }
             ),
         )
 
@@ -95,10 +104,49 @@ class ConfigFlow(ConfigFlowBase, domain=DOMAIN):
         self.data[CONF_SERVICES] = services
 
         entry = await self.async_set_unique_id(self.data[CONF_USERNAME])
-        if self.source == SOURCE_REAUTH:
+
+        if self.source == config_entries.SOURCE_REAUTH:
             self.hass.config_entries.async_update_entry(entry, data=self.data)
             await self.hass.config_entries.async_reload(entry.entry_id)
             return self.async_abort(reason="reauth_successful")
 
         self._abort_if_unique_id_configured()
         return self.async_create_entry(title=self.data[CONF_USERNAME], data=self.data)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
+        """Get the options flow for this handler."""
+        return OptionsFlowHandler(config_entry)
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Options flow for picking services."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            print(user_input)
+            return self.async_create_entry(title="", data=user_input)
+            # await self.hass.config_entries.async_reload(self.config_entry.entry_id)
+
+        data = self.hass.data[DOMAIN][self.config_entry.entry_id]
+        services = await data["client"].get_services()
+        service_options = {str(s[SERVICE_ID]): s["description"] for s in services}
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_SERVICES,
+                        default=self.config_entry.options.get(CONF_SERVICES),
+                    ): cv.multi_select(service_options)
+                }
+            ),
+        )

--- a/homeassistant/components/aussie_broadband/const.py
+++ b/homeassistant/components/aussie_broadband/const.py
@@ -2,3 +2,4 @@
 
 DOMAIN = "aussie_broadband"
 CONF_SERVICE_ID = "service_id"
+CONF_SERVICES = "services"

--- a/homeassistant/components/aussie_broadband/const.py
+++ b/homeassistant/components/aussie_broadband/const.py
@@ -1,5 +1,5 @@
 """Constants for the Aussie Broadband integration."""
 
 DOMAIN = "aussie_broadband"
-CONF_SERVICE_ID = "service_id"
+SERVICE_ID = "service_id"
 CONF_SERVICES = "services"

--- a/homeassistant/components/aussie_broadband/const.py
+++ b/homeassistant/components/aussie_broadband/const.py
@@ -1,5 +1,5 @@
 """Constants for the Aussie Broadband integration."""
-
+DEFAULT_UPDATE_INTERVAL = 30
 DOMAIN = "aussie_broadband"
 SERVICE_ID = "service_id"
 CONF_SERVICES = "services"

--- a/homeassistant/components/aussie_broadband/manifest.json
+++ b/homeassistant/components/aussie_broadband/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/aussie_broadband",
   "requirements": [
-    "pyaussiebb==0.0.8"
+    "pyaussiebb==0.0.9"
   ],
   "codeowners": [
     "@nickw444",

--- a/homeassistant/components/aussie_broadband/manifest.json
+++ b/homeassistant/components/aussie_broadband/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/aussie_broadband",
   "requirements": [
-    "pyaussiebb==0.0.3"
+    "pyaussiebb==0.0.4"
   ],
   "codeowners": [
     "@nickw444",

--- a/homeassistant/components/aussie_broadband/manifest.json
+++ b/homeassistant/components/aussie_broadband/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/aussie_broadband",
   "requirements": [
-    "pyaussiebb==0.0.4"
+    "pyaussiebb==0.0.8"
   ],
   "codeowners": [
     "@nickw444",

--- a/homeassistant/components/aussie_broadband/sensor.py
+++ b/homeassistant/components/aussie_broadband/sensor.py
@@ -26,7 +26,7 @@ async def async_setup_entry(
     client = hass.data[DOMAIN][entry.entry_id]["client"]
     services = hass.data[DOMAIN][entry.entry_id]["services"]
     UPDATE_INTERVAL = timedelta(
-        minutes=entry.options[CONF_SCAN_INTERVAL] or DEFAULT_UPDATE_INTERVAL
+        minutes=entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL)
     )
 
     entities = []

--- a/homeassistant/components/aussie_broadband/sensor.py
+++ b/homeassistant/components/aussie_broadband/sensor.py
@@ -29,7 +29,7 @@ async def async_setup_entry(
     service_id = entry.data[CONF_SERVICE_ID]
 
     async def async_update_data():
-        return await hass.async_add_executor_job(client.get_usage, service_id)
+        return await client.get_usage(service_id)
 
     coordinator = DataUpdateCoordinator(
         hass,

--- a/homeassistant/components/aussie_broadband/sensor.py
+++ b/homeassistant/components/aussie_broadband/sensor.py
@@ -6,7 +6,7 @@ import logging
 
 from homeassistant.components.sensor import STATE_CLASS_TOTAL_INCREASING, SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import DATA_MEGABYTES
+from homeassistant.const import DATA_MEGABYTES, DATA_KILOBYTES
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
@@ -33,7 +33,7 @@ async def async_setup_entry(
 
         async def async_update_data():
             if service["type"] == "PhoneMobile":
-                pass  # return await client.get_phoneusage(service[SERVICE_ID])
+                return await client.telephony_usage(service[SERVICE_ID])
             return await client.get_usage(service[SERVICE_ID])
 
         coordinator = DataUpdateCoordinator(
@@ -48,7 +48,10 @@ async def async_setup_entry(
         if service["type"] == "PhoneMobile":
             entities.extend(
                 [
-                    # AussieBroadandDownloaded(coordinator, service),
+                    AussieBroadandPhoneInternet(coordinator, service),
+                    AussieBroadandPhoneNational(coordinator, service),
+                    AussieBroadandPhoneMobile(coordinator, service),
+                    AussieBroadandPhoneSMS(coordinator, service),
                     AussieBroadandBillingCycleLength(coordinator, service),
                     AussieBroadandBillingCycleRemaining(coordinator, service),
                 ]
@@ -72,6 +75,7 @@ class AussieBroadandSensorEntity(CoordinatorEntity, SensorEntity):
     """Base class for Aussie Broadband metric sensors."""
 
     _attribute: str
+    _name: str
 
     def __init__(
         self,
@@ -81,10 +85,11 @@ class AussieBroadandSensorEntity(CoordinatorEntity, SensorEntity):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{service[SERVICE_ID]}:{self._attribute}"
+        self._attr_name = f"{service['name']} {self._name}"
 
     @property
     def state(self):
-        """Return the state of the device."""
+        """Return the state of the sensor."""
         return self.coordinator.data[self._attribute]
 
 
@@ -92,7 +97,7 @@ class AussieBroadandTotalUsage(AussieBroadandSensorEntity):
     """Representation of a Aussie Broadband Total Usage sensor."""
 
     _attribute = "usedMb"
-    _attr_name = "Total Usage"
+    _name = "Total Usage"
     _attr_unit_of_measurement = DATA_MEGABYTES
     _attr_state_class = STATE_CLASS_TOTAL_INCREASING
 
@@ -101,7 +106,7 @@ class AussieBroadandDownloaded(AussieBroadandSensorEntity):
     """Representation of a Aussie Broadband Download Usage sensor."""
 
     _attribute = "downloadedMb"
-    _attr_name = "Downloaded"
+    _name = "Downloaded"
     _attr_unit_of_measurement = DATA_MEGABYTES
     _attr_state_class = STATE_CLASS_TOTAL_INCREASING
 
@@ -110,7 +115,7 @@ class AussieBroadandUploaded(AussieBroadandSensorEntity):
     """Representation of a Aussie Broadband Upload Usage sensor."""
 
     _attribute = "uploadedMb"
-    _attr_name = "Uploaded"
+    _name = "Uploaded"
     _attr_unit_of_measurement = DATA_MEGABYTES
     _attr_state_class = STATE_CLASS_TOTAL_INCREASING
 
@@ -119,7 +124,7 @@ class AussieBroadandBillingCycleLength(AussieBroadandSensorEntity):
     """Representation of a Aussie Broadband Billing Cycle Length sensor."""
 
     _attribute = "daysTotal"
-    _attr_name = "Billing Cycle Length"
+    _name = "Billing Cycle Length"
     _attr_unit_of_measurement = "days"
 
 
@@ -127,5 +132,58 @@ class AussieBroadandBillingCycleRemaining(AussieBroadandSensorEntity):
     """Representation of a Aussie Broadband Billing Cycle Remaining sensor."""
 
     _attribute = "daysRemaining"
-    _attr_name = "Billing Cycle Remaining"
+    _name = "Billing Cycle Remaining"
     _attr_unit_of_measurement = "days"
+
+
+class AussieBroadandPhoneInternet(AussieBroadandSensorEntity):
+    """Representation of a Aussie Broadband Phone Data Usage sensor."""
+
+    _attribute = "internet"
+    _name = "Data Used"
+    _attr_unit_of_measurement = DATA_KILOBYTES
+    _attr_state_class = STATE_CLASS_TOTAL_INCREASING
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self.coordinator.data[self._attribute]["kbytes"]
+
+
+class AussieBroadandPhoneNational(AussieBroadandSensorEntity):
+    """Representation of a Aussie Broadband Phone Data Usaage sensor."""
+
+    _attribute = "national"
+    _name = "National Calls"
+    _attr_state_class = STATE_CLASS_TOTAL_INCREASING
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self.coordinator.data[self._attribute]["calls"]
+
+
+class AussieBroadandPhoneMobile(AussieBroadandSensorEntity):
+    """Representation of a Aussie Broadband Phone Data Usaage sensor."""
+
+    _attribute = "mobile"
+    _name = "Mobile Calls"
+    _attr_state_class = STATE_CLASS_TOTAL_INCREASING
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self.coordinator.data[self._attribute]["calls"]
+
+
+class AussieBroadandPhoneSMS(AussieBroadandSensorEntity):
+    """Representation of a Aussie Broadband Phone SMS count sensor."""
+
+    _attribute = "sms"
+    _name = "SMS Sent"
+    _attr_state_class = STATE_CLASS_TOTAL_INCREASING
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self.coordinator.data[self._attribute]["calls"]

--- a/homeassistant/components/aussie_broadband/sensor.py
+++ b/homeassistant/components/aussie_broadband/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .const import CONF_SERVICE_ID, DOMAIN
+from .const import DOMAIN, SERVICE_ID
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,13 +29,12 @@ async def async_setup_entry(
     services = hass.data[DOMAIN][entry.entry_id]["services"]
 
     entities = []
-
     for service in services:
 
         async def async_update_data():
-            if service.type == "PhoneMobile":
-                return await client.get_phoneusage(service[CONF_SERVICE_ID])
-            return await client.get_usage(service[CONF_SERVICE_ID])
+            if service["type"] == "PhoneMobile":
+                pass  # return await client.get_phoneusage(service[SERVICE_ID])
+            return await client.get_usage(service[SERVICE_ID])
 
         coordinator = DataUpdateCoordinator(
             hass,
@@ -46,12 +45,10 @@ async def async_setup_entry(
         )
         await coordinator.async_refresh()
 
-        if service.type == "PhoneMobile":
+        if service["type"] == "PhoneMobile":
             entities.extend(
                 [
-                    # AussieBroadandTotalUsage(coordinator, service),
-                    AussieBroadandDownloaded(coordinator, service),
-                    # AussieBroadandUploaded(coordinator, service),
+                    # AussieBroadandDownloaded(coordinator, service),
                     AussieBroadandBillingCycleLength(coordinator, service),
                     AussieBroadandBillingCycleRemaining(coordinator, service),
                 ]
@@ -79,11 +76,11 @@ class AussieBroadandSensorEntity(CoordinatorEntity, SensorEntity):
     def __init__(
         self,
         coordinator: DataUpdateCoordinator,
-        service_id: int,
+        service: dict,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{service_id}:{self._attribute}"
+        self._attr_unique_id = f"{service[SERVICE_ID]}:{self._attribute}"
 
     @property
     def state(self):

--- a/homeassistant/components/aussie_broadband/sensor.py
+++ b/homeassistant/components/aussie_broadband/sensor.py
@@ -44,7 +44,8 @@ async def async_setup_entry(
             update_interval=UPDATE_INTERVAL,
             update_method=async_update_data,
         )
-        await coordinator.async_refresh()
+        # await coordinator.async_refresh()
+        await coordinator.async_config_entry_first_refresh()
 
         if service["type"] == "PhoneMobile":
             entities.extend(

--- a/homeassistant/components/aussie_broadband/sensor.py
+++ b/homeassistant/components/aussie_broadband/sensor.py
@@ -6,7 +6,7 @@ import logging
 
 from homeassistant.components.sensor import STATE_CLASS_TOTAL_INCREASING, SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import DATA_MEGABYTES, DATA_KILOBYTES
+from homeassistant.const import DATA_KILOBYTES, DATA_MEGABYTES
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (

--- a/homeassistant/components/aussie_broadband/sensor.py
+++ b/homeassistant/components/aussie_broadband/sensor.py
@@ -25,31 +25,49 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ):
     """Set up Aussie Broadband sensor from a config entry."""
-    client = hass.data[DOMAIN][entry.entry_id]
-    service_id = entry.data[CONF_SERVICE_ID]
+    client = hass.data[DOMAIN][entry.entry_id]["client"]
+    services = hass.data[DOMAIN][entry.entry_id]["services"]
 
-    async def async_update_data():
-        return await client.get_usage(service_id)
+    entities = []
 
-    coordinator = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name="sensor",
-        update_interval=UPDATE_INTERVAL,
-        update_method=async_update_data,
-    )
-    await coordinator.async_refresh()
+    for service in services:
 
-    async_add_entities(
-        [
-            AussieBroadandTotalUsage(coordinator, service_id),
-            AussieBroadandDownloaded(coordinator, service_id),
-            AussieBroadandUploaded(coordinator, service_id),
-            AussieBroadandBillingCycleLength(coordinator, service_id),
-            AussieBroadandBillingCycleRemaining(coordinator, service_id),
-        ]
-    )
+        async def async_update_data():
+            if service.type == "PhoneMobile":
+                return await client.get_phoneusage(service[CONF_SERVICE_ID])
+            return await client.get_usage(service[CONF_SERVICE_ID])
 
+        coordinator = DataUpdateCoordinator(
+            hass,
+            _LOGGER,
+            name=service["service_id"],
+            update_interval=UPDATE_INTERVAL,
+            update_method=async_update_data,
+        )
+        await coordinator.async_refresh()
+
+        if service.type == "PhoneMobile":
+            entities.extend(
+                [
+                    # AussieBroadandTotalUsage(coordinator, service),
+                    AussieBroadandDownloaded(coordinator, service),
+                    # AussieBroadandUploaded(coordinator, service),
+                    AussieBroadandBillingCycleLength(coordinator, service),
+                    AussieBroadandBillingCycleRemaining(coordinator, service),
+                ]
+            )
+        else:
+            entities.extend(
+                [
+                    AussieBroadandTotalUsage(coordinator, service),
+                    AussieBroadandDownloaded(coordinator, service),
+                    AussieBroadandUploaded(coordinator, service),
+                    AussieBroadandBillingCycleLength(coordinator, service),
+                    AussieBroadandBillingCycleRemaining(coordinator, service),
+                ]
+            )
+
+    async_add_entities(entities)
     return True
 
 

--- a/homeassistant/components/aussie_broadband/sensor.py
+++ b/homeassistant/components/aussie_broadband/sensor.py
@@ -142,7 +142,7 @@ class AussieBroadandPhoneInternet(AussieBroadandSensorEntity):
     """Representation of a Aussie Broadband Phone Data Usage sensor."""
 
     _attribute = "internet"
-    _name = "Data Used"
+    _name = "Data Usage"
     _attr_unit_of_measurement = DATA_KILOBYTES
     _attr_state_class = STATE_CLASS_TOTAL_INCREASING
 

--- a/homeassistant/components/aussie_broadband/sensor.py
+++ b/homeassistant/components/aussie_broadband/sensor.py
@@ -22,31 +22,33 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ):
-    """Set up Aussie Broadband sensor from a config entry."""
+    """Set up the Aussie Broadband sensor platform from a config entry."""
     client = hass.data[DOMAIN][entry.entry_id]["client"]
     services = hass.data[DOMAIN][entry.entry_id]["services"]
-    UPDATE_INTERVAL = timedelta(
+    update_interval = timedelta(
         minutes=entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL)
     )
 
+    # Create an appropriate refresh function
+    def update_data_factory(service_id):
+        async def async_update_data():
+            return await client.get_usage(service_id)
+
+        return async_update_data
+
     entities = []
     for service in services:
-
-        async def async_update_data():
-            if service["type"] == "PhoneMobile":
-                return await client.telephony_usage(service[SERVICE_ID])
-            return await client.get_usage(service[SERVICE_ID])
-
+        # Initiate a Data Update Coordinator for this endpoint
         coordinator = DataUpdateCoordinator(
             hass,
             _LOGGER,
             name=service["service_id"],
-            update_interval=UPDATE_INTERVAL,
-            update_method=async_update_data,
-        )
-        # await coordinator.async_refresh()
+            update_interval=update_interval,
+            update_method=update_data_factory(service[SERVICE_ID]),
+        )  # type: DataUpdateCoordinator
         await coordinator.async_config_entry_first_refresh()
 
+        # Create the appropriate entities based on the service type
         if service["type"] == "PhoneMobile":
             entities.extend(
                 [

--- a/homeassistant/components/aussie_broadband/sensor.py
+++ b/homeassistant/components/aussie_broadband/sensor.py
@@ -6,7 +6,7 @@ import logging
 
 from homeassistant.components.sensor import STATE_CLASS_TOTAL_INCREASING, SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import DATA_KILOBYTES, DATA_MEGABYTES
+from homeassistant.const import CONF_SCAN_INTERVAL, DATA_KILOBYTES, DATA_MEGABYTES
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
@@ -18,8 +18,6 @@ from .const import DEFAULT_UPDATE_INTERVAL, DOMAIN, SERVICE_ID
 
 _LOGGER = logging.getLogger(__name__)
 
-UPDATE_INTERVAL = timedelta(minutes=DEFAULT_UPDATE_INTERVAL)  # 30
-
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -27,6 +25,9 @@ async def async_setup_entry(
     """Set up Aussie Broadband sensor from a config entry."""
     client = hass.data[DOMAIN][entry.entry_id]["client"]
     services = hass.data[DOMAIN][entry.entry_id]["services"]
+    UPDATE_INTERVAL = timedelta(
+        minutes=entry.options[CONF_SCAN_INTERVAL] or DEFAULT_UPDATE_INTERVAL
+    )
 
     entities = []
     for service in services:

--- a/homeassistant/components/aussie_broadband/sensor.py
+++ b/homeassistant/components/aussie_broadband/sensor.py
@@ -14,11 +14,11 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .const import DOMAIN, SERVICE_ID
+from .const import DEFAULT_UPDATE_INTERVAL, DOMAIN, SERVICE_ID
 
 _LOGGER = logging.getLogger(__name__)
 
-UPDATE_INTERVAL = timedelta(minutes=30)
+UPDATE_INTERVAL = timedelta(minutes=DEFAULT_UPDATE_INTERVAL)  # 30
 
 
 async def async_setup_entry(

--- a/homeassistant/components/aussie_broadband/strings.json
+++ b/homeassistant/components/aussie_broadband/strings.json
@@ -13,8 +13,12 @@
           "services": "Services"
         }
       },
-      "reauth_confirm": {
-        "title": "[%key:common::config_flow::title::reauth%]"
+      "reauth": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
       }
     },
     "error": {

--- a/homeassistant/components/aussie_broadband/strings.json
+++ b/homeassistant/components/aussie_broadband/strings.json
@@ -10,8 +10,7 @@
       "service": {
         "title": "Select Services",
         "data": {
-          "services": "Services",
-          "scan_interval": "Update Interval (minutes)"
+          "services": "Services"
         }
       },
       "reauth": {

--- a/homeassistant/components/aussie_broadband/strings.json
+++ b/homeassistant/components/aussie_broadband/strings.json
@@ -8,9 +8,9 @@
         }
       },
       "service": {
-        "title": "Select Service",
+        "title": "Select Services",
         "data": {
-          "service_id": "Service"
+          "services": "Services"
         }
       },
       "reauth_confirm": {
@@ -24,6 +24,16 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
       "no_services_found": "No services were found for this account",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Select Services",
+        "data": {
+          "services": "Services"
+        }
+      }
     }
   }
 }

--- a/homeassistant/components/aussie_broadband/strings.json
+++ b/homeassistant/components/aussie_broadband/strings.json
@@ -15,17 +15,18 @@
       },
       "reauth": {
         "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "Update password for {username}",
         "data": {
-          "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
         }
       }
     },
     "error": {
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
       "no_services_found": "No services were found for this account",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
@@ -39,6 +40,11 @@
           "scan_interval": "Update Interval (minutes)"
         }
       }
+    },
+    "abort": {
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   }
 }

--- a/homeassistant/components/aussie_broadband/strings.json
+++ b/homeassistant/components/aussie_broadband/strings.json
@@ -10,7 +10,8 @@
       "service": {
         "title": "Select Services",
         "data": {
-          "services": "Services"
+          "services": "Services",
+          "scan_interval": "Update Interval (minutes)"
         }
       },
       "reauth": {
@@ -35,7 +36,8 @@
       "init": {
         "title": "Select Services",
         "data": {
-          "services": "Services"
+          "services": "Services",
+          "scan_interval": "Update Interval (minutes)"
         }
       }
     }

--- a/homeassistant/components/aussie_broadband/translations/en.json
+++ b/homeassistant/components/aussie_broadband/translations/en.json
@@ -14,15 +14,25 @@
             },
             "service": {
                 "data": {
-                    "service_id": "Service"
+                    "services": "Services"
                 },
-                "title": "Select Service"
+                "title": "Select Services"
             },
             "user": {
                 "data": {
                     "password": "Password",
                     "username": "Username"
                 }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "services": "Services"
+                },
+                "title": "Select Services"
             }
         }
     }

--- a/homeassistant/components/aussie_broadband/translations/en.json
+++ b/homeassistant/components/aussie_broadband/translations/en.json
@@ -1,24 +1,24 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Service is already configured",
+            "already_configured": "Account is already configured",
             "no_services_found": "No services were found for this account",
             "reauth_successful": "Re-authentication was successful"
         },
         "error": {
+            "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication"
         },
         "step": {
             "reauth": {
                 "data": {
-                    "password": "Password",
-                    "username": "Username"
+                    "password": "Password"
                 },
+                "description": "Update password for {username}",
                 "title": "Reauthenticate Integration"
             },
             "service": {
                 "data": {
-                    "scan_interval": "Update Interval (minutes)",
                     "services": "Services"
                 },
                 "title": "Select Services"
@@ -32,6 +32,10 @@
         }
     },
     "options": {
+        "abort": {
+            "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid authentication"
+        },
         "step": {
             "init": {
                 "data": {

--- a/homeassistant/components/aussie_broadband/translations/en.json
+++ b/homeassistant/components/aussie_broadband/translations/en.json
@@ -9,11 +9,16 @@
             "invalid_auth": "Invalid authentication"
         },
         "step": {
-            "reauth_confirm": {
+            "reauth": {
+                "data": {
+                    "password": "Password",
+                    "username": "Username"
+                },
                 "title": "Reauthenticate Integration"
             },
             "service": {
                 "data": {
+                    "scan_interval": "Update Interval (minutes)",
                     "services": "Services"
                 },
                 "title": "Select Services"
@@ -30,6 +35,7 @@
         "step": {
             "init": {
                 "data": {
+                    "scan_interval": "Update Interval (minutes)",
                     "services": "Services"
                 },
                 "title": "Select Services"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1333,7 +1333,7 @@ pyatome==0.1.1
 pyatv==0.8.2
 
 # homeassistant.components.aussie_broadband
-pyaussiebb==0.0.4
+pyaussiebb==0.0.8
 
 # homeassistant.components.bbox
 pybbox==0.0.5-alpha

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1333,7 +1333,7 @@ pyatome==0.1.1
 pyatv==0.8.2
 
 # homeassistant.components.aussie_broadband
-pyaussiebb==0.0.8
+pyaussiebb==0.0.9
 
 # homeassistant.components.bbox
 pybbox==0.0.5-alpha

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1333,7 +1333,7 @@ pyatome==0.1.1
 pyatv==0.8.2
 
 # homeassistant.components.aussie_broadband
-pyaussiebb==0.0.3
+pyaussiebb==0.0.4
 
 # homeassistant.components.bbox
 pybbox==0.0.5-alpha

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -757,7 +757,7 @@ pyatmo==5.2.3
 pyatv==0.8.2
 
 # homeassistant.components.aussie_broadband
-pyaussiebb==0.0.8
+pyaussiebb==0.0.9
 
 # homeassistant.components.blackbird
 pyblackbird==0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -757,7 +757,7 @@ pyatmo==5.2.3
 pyatv==0.8.2
 
 # homeassistant.components.aussie_broadband
-pyaussiebb==0.0.3
+pyaussiebb==0.0.4
 
 # homeassistant.components.blackbird
 pyblackbird==0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -757,7 +757,7 @@ pyatmo==5.2.3
 pyatv==0.8.2
 
 # homeassistant.components.aussie_broadband
-pyaussiebb==0.0.4
+pyaussiebb==0.0.8
 
 # homeassistant.components.blackbird
 pyblackbird==0.5

--- a/tests/components/aussie_broadband/common.py
+++ b/tests/components/aussie_broadband/common.py
@@ -2,12 +2,27 @@
 from unittest.mock import patch
 
 from homeassistant.components.aussie_broadband.const import (
-    CONF_SERVICE_ID,
+    CONF_SERVICES,
     DOMAIN as AUSSIE_BROADBAND_DOMAIN,
 )
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
 
 from tests.common import MockConfigEntry
+
+FAKE_SERVICES = [
+    {
+        "service_id": "12345678",
+        "description": "Fake ABB NBN Service",
+        "type": "NBN",
+        "name": "NBN",
+    },
+    {
+        "service_id": "87654321",
+        "description": "Fake ABB Mobile Service",
+        "type": "PhoneMobile",
+        "name": "Mobile",
+    },
+]
 
 
 async def setup_platform(hass, platform, side_effect=None):
@@ -15,16 +30,20 @@ async def setup_platform(hass, platform, side_effect=None):
     mock_entry = MockConfigEntry(
         domain=AUSSIE_BROADBAND_DOMAIN,
         data={
-            CONF_USERNAME: "user@email.com",
-            CONF_PASSWORD: "password",
-            CONF_SERVICE_ID: "12345678",
+            CONF_USERNAME: "test-username",
+            CONF_PASSWORD: "test-password",
         },
+        options={CONF_SERVICES: ["12345678", "87654321"], CONF_SCAN_INTERVAL: 30},
     )
     mock_entry.add_to_hass(hass)
 
     with patch(
         "homeassistant.components.aussie_broadband.PLATFORMS", [platform]
-    ), patch("aussiebb.AussieBB.__init__", return_value=None, side_effect=side_effect):
+    ), patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
+        "aussiebb.asyncio.AussieBB.login", return_value=True, side_effect=side_effect
+    ), patch(
+        "aussiebb.asyncio.AussieBB.get_services", return_value=FAKE_SERVICES
+    ):
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/components/aussie_broadband/common.py
+++ b/tests/components/aussie_broadband/common.py
@@ -24,25 +24,31 @@ FAKE_SERVICES = [
     },
 ]
 
+FAKE_DATA = {
+    CONF_USERNAME: "test-username",
+    CONF_PASSWORD: "test-password",
+}
 
-async def setup_platform(hass, platform, side_effect=None):
+
+async def setup_platform(hass, platforms=[], side_effect=None):
     """Set up the Aussie Broadband platform."""
     mock_entry = MockConfigEntry(
         domain=AUSSIE_BROADBAND_DOMAIN,
-        data={
-            CONF_USERNAME: "test-username",
-            CONF_PASSWORD: "test-password",
-        },
+        data=FAKE_DATA,
         options={CONF_SERVICES: ["12345678", "87654321"], CONF_SCAN_INTERVAL: 30},
     )
     mock_entry.add_to_hass(hass)
 
-    with patch(
-        "homeassistant.components.aussie_broadband.PLATFORMS", [platform]
-    ), patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
-        "aussiebb.asyncio.AussieBB.login", return_value=True, side_effect=side_effect
+    with patch("homeassistant.components.aussie_broadband.PLATFORMS", platforms), patch(
+        "aussiebb.asyncio.AussieBB.__init__", return_value=None
     ), patch(
-        "aussiebb.asyncio.AussieBB.get_services", return_value=FAKE_SERVICES
+        "aussiebb.asyncio.AussieBB.login",
+        return_value=True,
+        side_effect=side_effect,
+    ), patch(
+        "aussiebb.asyncio.AussieBB.get_services",
+        return_value=FAKE_SERVICES,
+        side_effect=side_effect,
     ):
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/aussie_broadband/test_config_flow.py
+++ b/tests/components/aussie_broadband/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the Aussie Broadband config flow."""
 from unittest.mock import patch
 
-from aussiebb import AuthenticationException
+from aussiebb.asyncio import AuthenticationException
 
 from homeassistant import config_entries, setup
 from homeassistant.components.aussie_broadband.const import DOMAIN

--- a/tests/components/aussie_broadband/test_config_flow.py
+++ b/tests/components/aussie_broadband/test_config_flow.py
@@ -88,7 +88,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
     assert result4["type"] == RESULT_TYPE_ABORT
 
-    # Test reauth
+    # Test failed reauth
     result5 = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_REAUTH},
@@ -100,19 +100,35 @@ async def test_form(hass: HomeAssistant) -> None:
     assert result5["step_id"] == "reauth"
 
     with patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
-        "aussiebb.asyncio.AussieBB.login", return_value=True
+        "aussiebb.asyncio.AussieBB.login", side_effect=AuthenticationException()
     ), patch("aussiebb.asyncio.AussieBB.get_services", return_value=[FAKE_SERVICES[0]]):
 
         result6 = await hass.config_entries.flow.async_configure(
             result5["flow_id"],
+            {
+                CONF_PASSWORD: "test-wrongpassword",
+            },
+        )
+        await hass.async_block_till_done()
+
+        assert result6["step_id"] == "reauth"
+
+    # Test successful reauth
+
+    with patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
+        "aussiebb.asyncio.AussieBB.login", return_value=True
+    ), patch("aussiebb.asyncio.AussieBB.get_services", return_value=[FAKE_SERVICES[0]]):
+
+        result7 = await hass.config_entries.flow.async_configure(
+            result6["flow_id"],
             {
                 CONF_PASSWORD: "test-newpassword",
             },
         )
         await hass.async_block_till_done()
 
-        assert result6["type"] == "abort"
-        assert result6["reason"] == "reauth_successful"
+        assert result7["type"] == "abort"
+        assert result7["reason"] == "reauth_successful"
 
 
 async def test_no_services(hass: HomeAssistant) -> None:

--- a/tests/components/aussie_broadband/test_config_flow.py
+++ b/tests/components/aussie_broadband/test_config_flow.py
@@ -5,7 +5,7 @@ from aussiebb.asyncio import AuthenticationException
 
 from homeassistant import config_entries
 from homeassistant.components.aussie_broadband.const import CONF_SERVICES, DOMAIN
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME  # CONF_SCAN_INTERVAL
+from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (
     RESULT_TYPE_ABORT,
@@ -13,22 +13,10 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_FORM,
 )
 
-TEST_USERNAME = "test-username"
-TEST_PASSWORD = "test-password"
-FAKE_SERVICES = [
-    {
-        "service_id": "12345678",
-        "description": "Fake ABB NBN Service",
-        "type": "NBN",
-        "name": "NBN",
-    },
-    {
-        "service_id": "87654321",
-        "description": "Fake ABB Mobile Service",
-        "type": "PhoneMobile",
-        "name": "Mobile",
-    },
-]
+from .common import FAKE_DATA, FAKE_SERVICES, setup_platform
+
+TEST_USERNAME = FAKE_DATA[CONF_USERNAME]
+TEST_PASSWORD = FAKE_DATA[CONF_PASSWORD]
 
 
 async def test_form(hass: HomeAssistant) -> None:
@@ -49,10 +37,7 @@ async def test_form(hass: HomeAssistant) -> None:
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result1["flow_id"],
-            {
-                CONF_USERNAME: TEST_USERNAME,
-                CONF_PASSWORD: TEST_PASSWORD,
-            },
+            FAKE_DATA,
         )
         await hass.async_block_till_done()
 
@@ -65,37 +50,11 @@ async def test_form(hass: HomeAssistant) -> None:
     assert result2["options"] == {CONF_SERVICES: ["12345678"]}
     assert len(mock_setup_entry.mock_calls) == 1
 
-    # Test Already configured
-    result3 = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    with patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
-        "aussiebb.asyncio.AussieBB.login", return_value=True
-    ), patch(
-        "aussiebb.asyncio.AussieBB.get_services", return_value=[FAKE_SERVICES[0]]
-    ), patch(
-        "homeassistant.components.aussie_broadband.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result4 = await hass.config_entries.flow.async_configure(
-            result3["flow_id"],
-            {
-                CONF_USERNAME: TEST_USERNAME,
-                CONF_PASSWORD: TEST_PASSWORD,
-            },
-        )
-        await hass.async_block_till_done()
-
-    assert result4["type"] == RESULT_TYPE_ABORT
-
     # Test failed reauth
     result5 = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_REAUTH},
-        data={
-            CONF_USERNAME: TEST_USERNAME,
-            CONF_PASSWORD: TEST_PASSWORD,
-        },
+        data=FAKE_DATA,
     )
     assert result5["step_id"] == "reauth"
 
@@ -131,6 +90,49 @@ async def test_form(hass: HomeAssistant) -> None:
         assert result7["reason"] == "reauth_successful"
 
 
+async def test_already_configured(hass: HomeAssistant) -> None:
+    """Test already configured."""
+    # entry = await setup_platform(hass)
+    result1 = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
+        "aussiebb.asyncio.AussieBB.login", return_value=True
+    ), patch(
+        "aussiebb.asyncio.AussieBB.get_services", return_value=[FAKE_SERVICES[0]]
+    ), patch(
+        "homeassistant.components.aussie_broadband.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        await hass.config_entries.flow.async_configure(
+            result1["flow_id"],
+            FAKE_DATA,
+        )
+        await hass.async_block_till_done()
+
+    # Test Already configured
+    result3 = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    with patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
+        "aussiebb.asyncio.AussieBB.login", return_value=True
+    ), patch(
+        "aussiebb.asyncio.AussieBB.get_services", return_value=[FAKE_SERVICES[0]]
+    ), patch(
+        "homeassistant.components.aussie_broadband.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
+            FAKE_DATA,
+        )
+        await hass.async_block_till_done()
+
+    assert result4["type"] == RESULT_TYPE_ABORT
+    assert len(mock_setup_entry.mock_calls) == 0
+
+
 async def test_no_services(hass: HomeAssistant) -> None:
     """Test when there are no services."""
     result1 = await hass.config_entries.flow.async_init(
@@ -147,10 +149,7 @@ async def test_no_services(hass: HomeAssistant) -> None:
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result1["flow_id"],
-            {
-                CONF_USERNAME: TEST_USERNAME,
-                CONF_PASSWORD: TEST_PASSWORD,
-            },
+            FAKE_DATA,
         )
         await hass.async_block_till_done()
 
@@ -172,10 +171,7 @@ async def test_form_multiple_services(hass: HomeAssistant) -> None:
     ), patch("aussiebb.asyncio.AussieBB.get_services", return_value=FAKE_SERVICES):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                CONF_USERNAME: TEST_USERNAME,
-                CONF_PASSWORD: TEST_PASSWORD,
-            },
+            FAKE_DATA,
         )
         await hass.async_block_till_done()
 
@@ -195,10 +191,7 @@ async def test_form_multiple_services(hass: HomeAssistant) -> None:
 
     assert result3["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result3["title"] == TEST_USERNAME
-    assert result3["data"] == {
-        CONF_USERNAME: TEST_USERNAME,
-        CONF_PASSWORD: TEST_PASSWORD,
-    }
+    assert result3["data"] == FAKE_DATA
     assert result3["options"] == {
         CONF_SERVICES: [FAKE_SERVICES[1]["service_id"]],
     }
@@ -216,11 +209,26 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result1["flow_id"],
-            {
-                CONF_USERNAME: TEST_USERNAME,
-                CONF_PASSWORD: TEST_PASSWORD,
-            },
+            FAKE_DATA,
         )
 
     assert result2["type"] == RESULT_TYPE_FORM
     assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_options_flow(hass):
+    """Test options flow."""
+    entry = await setup_platform(hass)
+
+    with patch("aussiebb.asyncio.AussieBB.get_services", return_value=FAKE_SERVICES):
+
+        result3 = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result3["type"] == RESULT_TYPE_FORM
+        assert result3["step_id"] == "init"
+
+        result4 = await hass.config_entries.options.async_configure(
+            result3["flow_id"],
+            user_input={CONF_SERVICES: [], CONF_SCAN_INTERVAL: 61},
+        )
+        assert result4["type"] == RESULT_TYPE_CREATE_ENTRY
+        assert entry.options == {CONF_SERVICES: [], CONF_SCAN_INTERVAL: 61}

--- a/tests/components/aussie_broadband/test_config_flow.py
+++ b/tests/components/aussie_broadband/test_config_flow.py
@@ -1,6 +1,7 @@
 """Test the Aussie Broadband config flow."""
 from unittest.mock import patch
 
+from aiohttp import ClientConnectionError
 from aussiebb.asyncio import AuthenticationException
 
 from homeassistant import config_entries, setup
@@ -174,6 +175,24 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "invalid_auth"}
 
 
+async def test_form_network_issue(hass: HomeAssistant) -> None:
+    """Test network issues are handled."""
+    result1 = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
+        "aussiebb.asyncio.AussieBB.login", side_effect=ClientConnectionError()
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result1["flow_id"],
+            FAKE_DATA,
+        )
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+
 async def test_reauth(hass: HomeAssistant) -> None:
     """Test reauth flow."""
 
@@ -249,13 +268,41 @@ async def test_options_flow(hass):
 
     with patch("aussiebb.asyncio.AussieBB.get_services", return_value=FAKE_SERVICES):
 
-        result3 = await hass.config_entries.options.async_init(entry.entry_id)
-        assert result3["type"] == RESULT_TYPE_FORM
-        assert result3["step_id"] == "init"
+        result1 = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result1["type"] == RESULT_TYPE_FORM
+        assert result1["step_id"] == "init"
 
-        result4 = await hass.config_entries.options.async_configure(
-            result3["flow_id"],
+        result2 = await hass.config_entries.options.async_configure(
+            result1["flow_id"],
             user_input={CONF_SERVICES: [], CONF_SCAN_INTERVAL: 61},
         )
-        assert result4["type"] == RESULT_TYPE_CREATE_ENTRY
+        assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
         assert entry.options == {CONF_SERVICES: [], CONF_SCAN_INTERVAL: 61}
+
+
+async def test_options_flow_auth_failure(hass):
+    """Test options flow with auth failure."""
+
+    entry = await setup_platform(hass)
+
+    with patch(
+        "aussiebb.asyncio.AussieBB.get_services", side_effect=AuthenticationException()
+    ):
+
+        result1 = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result1["type"] == RESULT_TYPE_ABORT
+        assert result1["reason"] == "invalid_auth"
+
+
+async def test_options_flow_network_failure(hass):
+    """Test options flow with connectivity failure."""
+
+    entry = await setup_platform(hass)
+
+    with patch(
+        "aussiebb.asyncio.AussieBB.get_services", side_effect=ClientConnectionError()
+    ):
+
+        result1 = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result1["type"] == RESULT_TYPE_ABORT
+        assert result1["reason"] == "cannot_connect"

--- a/tests/components/aussie_broadband/test_config_flow.py
+++ b/tests/components/aussie_broadband/test_config_flow.py
@@ -306,3 +306,17 @@ async def test_options_flow_network_failure(hass):
         result1 = await hass.config_entries.options.async_init(entry.entry_id)
         assert result1["type"] == RESULT_TYPE_ABORT
         assert result1["reason"] == "cannot_connect"
+
+
+async def test_options_flow_not_loaded(hass):
+    """Test the options flow aborts when the entry has unloaded due to a reauth."""
+
+    entry = await setup_platform(hass)
+
+    with patch(
+        "aussiebb.asyncio.AussieBB.get_services", side_effect=AuthenticationException()
+    ):
+        entry.state = config_entries.ConfigEntryState.NOT_LOADED
+        result1 = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result1["type"] == RESULT_TYPE_ABORT
+        assert result1["reason"] == "unknown"

--- a/tests/components/aussie_broadband/test_config_flow.py
+++ b/tests/components/aussie_broadband/test_config_flow.py
@@ -3,14 +3,32 @@ from unittest.mock import patch
 
 from aussiebb.asyncio import AuthenticationException
 
-from homeassistant import config_entries, setup
-from homeassistant.components.aussie_broadband.const import DOMAIN
+from homeassistant import config_entries
+from homeassistant.components.aussie_broadband.const import CONF_SERVICES, DOMAIN
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME  # CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (
     RESULT_TYPE_ABORT,
     RESULT_TYPE_CREATE_ENTRY,
     RESULT_TYPE_FORM,
 )
+
+TEST_USERNAME = "test-username"
+TEST_PASSWORD = "test-password"
+FAKE_SERVICES = [
+    {
+        "service_id": "12345678",
+        "description": "Fake ABB NBN Service",
+        "type": "NBN",
+        "name": "NBN",
+    },
+    {
+        "service_id": "87654321",
+        "description": "Fake ABB Mobile Service",
+        "type": "PhoneMobile",
+        "name": "Mobile",
+    },
+]
 
 
 async def test_form(hass: HomeAssistant) -> None:
@@ -21,12 +39,10 @@ async def test_form(hass: HomeAssistant) -> None:
     assert result1["type"] == RESULT_TYPE_FORM
     assert result1["errors"] is None
 
-    fake_services = [
-        {"service_id": "12345678", "description": "Fake ABB Service"},
-    ]
-
-    with patch("aussiebb.AussieBB.__init__", return_value=None), patch(
-        "aussiebb.AussieBB.get_services", return_value=fake_services
+    with patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
+        "aussiebb.asyncio.AussieBB.login", return_value=True
+    ), patch(
+        "aussiebb.asyncio.AussieBB.get_services", return_value=[FAKE_SERVICES[0]]
     ), patch(
         "homeassistant.components.aussie_broadband.async_setup_entry",
         return_value=True,
@@ -34,27 +50,29 @@ async def test_form(hass: HomeAssistant) -> None:
         result2 = await hass.config_entries.flow.async_configure(
             result1["flow_id"],
             {
-                "username": "test-username",
-                "password": "test-password",
+                CONF_USERNAME: TEST_USERNAME,
+                CONF_PASSWORD: TEST_PASSWORD,
             },
         )
         await hass.async_block_till_done()
 
     assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result2["title"] == "Fake ABB Service"
+    assert result2["title"] == TEST_USERNAME
     assert result2["data"] == {
-        "service_id": "12345678",
-        "username": "test-username",
-        "password": "test-password",
+        CONF_USERNAME: TEST_USERNAME,
+        CONF_PASSWORD: TEST_PASSWORD,
     }
+    assert result2["options"] == {CONF_SERVICES: ["12345678"]}
     assert len(mock_setup_entry.mock_calls) == 1
 
     # Test Already configured
     result3 = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    with patch("aussiebb.AussieBB.__init__", return_value=None), patch(
-        "aussiebb.AussieBB.get_services", return_value=fake_services
+    with patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
+        "aussiebb.asyncio.AussieBB.login", return_value=True
+    ), patch(
+        "aussiebb.asyncio.AussieBB.get_services", return_value=[FAKE_SERVICES[0]]
     ), patch(
         "homeassistant.components.aussie_broadband.async_setup_entry",
         return_value=True,
@@ -62,13 +80,39 @@ async def test_form(hass: HomeAssistant) -> None:
         result4 = await hass.config_entries.flow.async_configure(
             result3["flow_id"],
             {
-                "username": "test-username",
-                "password": "test-password",
+                CONF_USERNAME: TEST_USERNAME,
+                CONF_PASSWORD: TEST_PASSWORD,
             },
         )
         await hass.async_block_till_done()
 
     assert result4["type"] == RESULT_TYPE_ABORT
+
+    # Test reauth
+    result5 = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_REAUTH},
+        data={
+            CONF_USERNAME: TEST_USERNAME,
+            CONF_PASSWORD: TEST_PASSWORD,
+        },
+    )
+    assert result5["step_id"] == "reauth"
+
+    with patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
+        "aussiebb.asyncio.AussieBB.login", return_value=True
+    ), patch("aussiebb.asyncio.AussieBB.get_services", return_value=[FAKE_SERVICES[0]]):
+
+        result6 = await hass.config_entries.flow.async_configure(
+            result5["flow_id"],
+            {
+                CONF_PASSWORD: "test-newpassword",
+            },
+        )
+        await hass.async_block_till_done()
+
+        assert result6["type"] == "abort"
+        assert result6["reason"] == "reauth_successful"
 
 
 async def test_no_services(hass: HomeAssistant) -> None:
@@ -79,19 +123,17 @@ async def test_no_services(hass: HomeAssistant) -> None:
     assert result1["type"] == RESULT_TYPE_FORM
     assert result1["errors"] is None
 
-    fake_services = []
-
-    with patch("aussiebb.AussieBB.__init__", return_value=None), patch(
-        "aussiebb.AussieBB.get_services", return_value=fake_services
-    ), patch(
+    with patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
+        "aussiebb.asyncio.AussieBB.login", return_value=True
+    ), patch("aussiebb.asyncio.AussieBB.get_services", return_value=[]), patch(
         "homeassistant.components.aussie_broadband.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result1["flow_id"],
             {
-                "username": "test-username",
-                "password": "test-password",
+                CONF_USERNAME: TEST_USERNAME,
+                CONF_PASSWORD: TEST_PASSWORD,
             },
         )
         await hass.async_block_till_done()
@@ -99,60 +141,6 @@ async def test_no_services(hass: HomeAssistant) -> None:
     assert result2["type"] == RESULT_TYPE_ABORT
     assert result2["reason"] == "no_services_found"
     assert len(mock_setup_entry.mock_calls) == 0
-
-
-async def test_form_duplicate_service(hass: HomeAssistant) -> None:
-    """Test form fails if adding a service twice."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] == RESULT_TYPE_FORM
-    assert result["errors"] is None
-
-    fake_services = [
-        {"service_id": "12345678", "description": "Fake ABB Service"},
-    ]
-
-    with patch("aussiebb.AussieBB.__init__", return_value=None), patch(
-        "aussiebb.AussieBB.get_services", return_value=fake_services
-    ), patch(
-        "homeassistant.components.aussie_broadband.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "username": "test-username",
-                "password": "test-password",
-            },
-        )
-        await hass.async_block_till_done()
-
-    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert len(mock_setup_entry.mock_calls) == 1
-
-    result3 = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result3["type"] == RESULT_TYPE_FORM
-    assert result3["errors"] is None
-    with patch("aussiebb.AussieBB.__init__", return_value=None), patch(
-        "aussiebb.AussieBB.get_services", return_value=fake_services
-    ), patch(
-        "homeassistant.components.aussie_broadband.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result4 = await hass.config_entries.flow.async_configure(
-            result3["flow_id"],
-            {
-                "username": "test-username",
-                "password": "test-password",
-            },
-        )
-        await hass.async_block_till_done()
-
-    assert result4["type"] == RESULT_TYPE_ABORT
-    assert result4["reason"] == "already_configured"
 
 
 async def test_form_multiple_services(hass: HomeAssistant) -> None:
@@ -163,19 +151,14 @@ async def test_form_multiple_services(hass: HomeAssistant) -> None:
     assert result["type"] == RESULT_TYPE_FORM
     assert result["errors"] is None
 
-    fake_services = [
-        {"service_id": "12345678", "description": "Fake ABB Service 1"},
-        {"service_id": "87654321", "description": "Fake ABB Service 2"},
-    ]
-
-    with patch("aussiebb.AussieBB.__init__", return_value=None), patch(
-        "aussiebb.AussieBB.get_services", return_value=fake_services
-    ):
+    with patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
+        "aussiebb.asyncio.AussieBB.login", return_value=True
+    ), patch("aussiebb.asyncio.AussieBB.get_services", return_value=FAKE_SERVICES):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
-                "username": "test-username",
-                "password": "test-password",
+                CONF_USERNAME: TEST_USERNAME,
+                CONF_PASSWORD: TEST_PASSWORD,
             },
         )
         await hass.async_block_till_done()
@@ -190,98 +173,20 @@ async def test_form_multiple_services(hass: HomeAssistant) -> None:
     ) as mock_setup_entry:
         result3 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {"service_id": "87654321"},
+            {CONF_SERVICES: [FAKE_SERVICES[1]["service_id"]]},
         )
         await hass.async_block_till_done()
 
     assert result3["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result3["title"] == "Fake ABB Service 2"
+    assert result3["title"] == TEST_USERNAME
     assert result3["data"] == {
-        "service_id": "87654321",
-        "username": "test-username",
-        "password": "test-password",
+        CONF_USERNAME: TEST_USERNAME,
+        CONF_PASSWORD: TEST_PASSWORD,
+    }
+    assert result3["options"] == {
+        CONF_SERVICES: [FAKE_SERVICES[1]["service_id"]],
     }
     assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_form_multiple_services_duplicate(hass: HomeAssistant) -> None:
-    """Test that the form fails if adding a service twice."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] == RESULT_TYPE_FORM
-    assert result["errors"] is None
-
-    fake_services = [
-        {"service_id": "12345678", "description": "Fake ABB Service 1"},
-        {"service_id": "87654321", "description": "Fake ABB Service 2"},
-    ]
-
-    with patch("aussiebb.AussieBB.__init__", return_value=None), patch(
-        "aussiebb.AussieBB.get_services", return_value=fake_services
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                "username": "test-username",
-                "password": "test-password",
-            },
-        )
-        await hass.async_block_till_done()
-
-    assert result2["type"] == RESULT_TYPE_FORM
-    assert result2["step_id"] == "service"
-    assert result2["errors"] is None
-
-    with patch(
-        "homeassistant.components.aussie_broadband.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result3 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"service_id": "87654321"},
-        )
-        await hass.async_block_till_done()
-
-    assert result3["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result3["title"] == "Fake ABB Service 2"
-    assert result3["data"] == {
-        "service_id": "87654321",
-        "username": "test-username",
-        "password": "test-password",
-    }
-    assert len(mock_setup_entry.mock_calls) == 1
-
-    result4 = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result4["type"] == RESULT_TYPE_FORM
-    assert result4["errors"] is None
-
-    with patch("aussiebb.AussieBB.__init__", return_value=None), patch(
-        "aussiebb.AussieBB.get_services", return_value=fake_services
-    ):
-        result5 = await hass.config_entries.flow.async_configure(
-            result4["flow_id"],
-            {
-                "username": "test-username",
-                "password": "test-password",
-            },
-        )
-        await hass.async_block_till_done()
-
-    assert result5["type"] == RESULT_TYPE_FORM
-    assert result5["step_id"] == "service"
-    assert result5["errors"] is None
-
-    result6 = await hass.config_entries.flow.async_configure(
-        result5["flow_id"],
-        {"service_id": "87654321"},
-    )
-    await hass.async_block_till_done()
-
-    assert result6["type"] == RESULT_TYPE_ABORT
-    assert result6["reason"] == "already_configured"
 
 
 async def test_form_invalid_auth(hass: HomeAssistant) -> None:
@@ -290,67 +195,16 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    with patch("aussiebb.AussieBB.__init__", side_effect=AuthenticationException()):
+    with patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
+        "aussiebb.asyncio.AussieBB.login", side_effect=AuthenticationException()
+    ):
         result2 = await hass.config_entries.flow.async_configure(
             result1["flow_id"],
             {
-                "username": "test-username",
-                "password": "test-password",
+                CONF_USERNAME: TEST_USERNAME,
+                CONF_PASSWORD: TEST_PASSWORD,
             },
         )
 
     assert result2["type"] == RESULT_TYPE_FORM
     assert result2["errors"] == {"base": "invalid_auth"}
-
-
-async def test_reauth(hass: HomeAssistant) -> None:
-    """Test reauth is handled."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
-    # Setup a config entry
-    result1 = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    fake_services = [
-        {"service_id": "12345678", "description": "Fake ABB Service"},
-    ]
-
-    with patch("aussiebb.AussieBB.__init__", return_value=None), patch(
-        "aussiebb.AussieBB.get_services", return_value=fake_services
-    ), patch(
-        "homeassistant.components.aussie_broadband.async_setup_entry",
-        return_value=True,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result1["flow_id"],
-            {
-                "username": "test-username",
-                "password": "test-password",
-            },
-        )
-        await hass.async_block_till_done()
-
-    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
-
-    # Trigger the reauth
-    result3 = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_REAUTH}
-    )
-    assert result3["step_id"] == "user"
-
-    with patch("aussiebb.AussieBB.__init__", return_value=None), patch(
-        "aussiebb.AussieBB.get_services", return_value=fake_services
-    ):
-
-        result4 = await hass.config_entries.flow.async_configure(
-            result3["flow_id"],
-            {
-                "username": "test-username",
-                "password": "test-newpassword",
-            },
-        )
-        await hass.async_block_till_done()
-
-        assert result4["type"] == "abort"
-        assert result4["reason"] == "reauth_successful"

--- a/tests/components/aussie_broadband/test_config_flow.py
+++ b/tests/components/aussie_broadband/test_config_flow.py
@@ -48,76 +48,6 @@ async def test_form(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_reauth(hass: HomeAssistant) -> None:
-    """Test reauth flow."""
-
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
-    # Test reauth but the entry doesn't exist
-    result1 = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=FAKE_DATA
-    )
-
-    with patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
-        "aussiebb.asyncio.AussieBB.login", return_value=True
-    ), patch(
-        "aussiebb.asyncio.AussieBB.get_services", return_value=[FAKE_SERVICES[0]]
-    ), patch(
-        "homeassistant.components.aussie_broadband.async_setup_entry",
-        return_value=True,
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result1["flow_id"],
-            {
-                CONF_PASSWORD: TEST_PASSWORD,
-            },
-        )
-        await hass.async_block_till_done()
-
-        assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
-        assert result2["title"] == TEST_USERNAME
-        assert result2["data"] == FAKE_DATA
-
-    # Test failed reauth
-    result5 = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_REAUTH},
-        data=FAKE_DATA,
-    )
-    assert result5["step_id"] == "reauth"
-
-    with patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
-        "aussiebb.asyncio.AussieBB.login", side_effect=AuthenticationException()
-    ), patch("aussiebb.asyncio.AussieBB.get_services", return_value=[FAKE_SERVICES[0]]):
-
-        result6 = await hass.config_entries.flow.async_configure(
-            result5["flow_id"],
-            {
-                CONF_PASSWORD: "test-wrongpassword",
-            },
-        )
-        await hass.async_block_till_done()
-
-        assert result6["step_id"] == "reauth"
-
-    # Test successful reauth
-
-    with patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
-        "aussiebb.asyncio.AussieBB.login", return_value=True
-    ), patch("aussiebb.asyncio.AussieBB.get_services", return_value=[FAKE_SERVICES[0]]):
-
-        result7 = await hass.config_entries.flow.async_configure(
-            result6["flow_id"],
-            {
-                CONF_PASSWORD: "test-newpassword",
-            },
-        )
-        await hass.async_block_till_done()
-
-        assert result7["type"] == "abort"
-        assert result7["reason"] == "reauth_successful"
-
-
 async def test_already_configured(hass: HomeAssistant) -> None:
     """Test already configured."""
     # Setup an entry
@@ -242,6 +172,75 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
 
     assert result2["type"] == RESULT_TYPE_FORM
     assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_reauth(hass: HomeAssistant) -> None:
+    """Test reauth flow."""
+
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    # Test reauth but the entry doesn't exist
+    result1 = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=FAKE_DATA
+    )
+
+    with patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
+        "aussiebb.asyncio.AussieBB.login", return_value=True
+    ), patch(
+        "aussiebb.asyncio.AussieBB.get_services", return_value=[FAKE_SERVICES[0]]
+    ), patch(
+        "homeassistant.components.aussie_broadband.async_setup_entry",
+        return_value=True,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result1["flow_id"],
+            {
+                CONF_PASSWORD: TEST_PASSWORD,
+            },
+        )
+        await hass.async_block_till_done()
+
+        assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
+        assert result2["title"] == TEST_USERNAME
+        assert result2["data"] == FAKE_DATA
+
+    # Test failed reauth
+    result5 = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_REAUTH},
+        data=FAKE_DATA,
+    )
+    assert result5["step_id"] == "reauth"
+
+    with patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
+        "aussiebb.asyncio.AussieBB.login", side_effect=AuthenticationException()
+    ), patch("aussiebb.asyncio.AussieBB.get_services", return_value=[FAKE_SERVICES[0]]):
+
+        result6 = await hass.config_entries.flow.async_configure(
+            result5["flow_id"],
+            {
+                CONF_PASSWORD: "test-wrongpassword",
+            },
+        )
+        await hass.async_block_till_done()
+
+        assert result6["step_id"] == "reauth"
+
+    # Test successful reauth
+    with patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
+        "aussiebb.asyncio.AussieBB.login", return_value=True
+    ), patch("aussiebb.asyncio.AussieBB.get_services", return_value=[FAKE_SERVICES[0]]):
+
+        result7 = await hass.config_entries.flow.async_configure(
+            result6["flow_id"],
+            {
+                CONF_PASSWORD: "test-newpassword",
+            },
+        )
+        await hass.async_block_till_done()
+
+        assert result7["type"] == "abort"
+        assert result7["reason"] == "reauth_successful"
 
 
 async def test_options_flow(hass):

--- a/tests/components/aussie_broadband/test_config_flow.py
+++ b/tests/components/aussie_broadband/test_config_flow.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from aussiebb.asyncio import AuthenticationException
 
-from homeassistant import config_entries
+from homeassistant import config_entries, setup
 from homeassistant.components.aussie_broadband.const import CONF_SERVICES, DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -43,12 +43,40 @@ async def test_form(hass: HomeAssistant) -> None:
 
     assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == TEST_USERNAME
-    assert result2["data"] == {
-        CONF_USERNAME: TEST_USERNAME,
-        CONF_PASSWORD: TEST_PASSWORD,
-    }
+    assert result2["data"] == FAKE_DATA
     assert result2["options"] == {CONF_SERVICES: ["12345678"]}
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_reauth(hass: HomeAssistant) -> None:
+    """Test reauth flow."""
+
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    # Test reauth but the entry doesn't exist
+    result1 = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_REAUTH}, data=FAKE_DATA
+    )
+
+    with patch("aussiebb.asyncio.AussieBB.__init__", return_value=None), patch(
+        "aussiebb.asyncio.AussieBB.login", return_value=True
+    ), patch(
+        "aussiebb.asyncio.AussieBB.get_services", return_value=[FAKE_SERVICES[0]]
+    ), patch(
+        "homeassistant.components.aussie_broadband.async_setup_entry",
+        return_value=True,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result1["flow_id"],
+            {
+                CONF_PASSWORD: TEST_PASSWORD,
+            },
+        )
+        await hass.async_block_till_done()
+
+        assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
+        assert result2["title"] == TEST_USERNAME
+        assert result2["data"] == FAKE_DATA
 
     # Test failed reauth
     result5 = await hass.config_entries.flow.async_init(
@@ -92,7 +120,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
 async def test_already_configured(hass: HomeAssistant) -> None:
     """Test already configured."""
-    # entry = await setup_platform(hass)
+    # Setup an entry
     result1 = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/aussie_broadband/test_init.py
+++ b/tests/components/aussie_broadband/test_init.py
@@ -1,7 +1,7 @@
 """Test the Aussie Broadband init."""
 from unittest.mock import patch
 
-from aussiebb import AuthenticationException
+from aussiebb.asyncio import AuthenticationException
 import requests
 
 from homeassistant import data_entry_flow

--- a/tests/components/aussie_broadband/test_init.py
+++ b/tests/components/aussie_broadband/test_init.py
@@ -1,8 +1,8 @@
 """Test the Aussie Broadband init."""
 from unittest.mock import patch
 
+from aiohttp import ClientConnectionError
 from aussiebb.asyncio import AuthenticationException
-import requests
 
 from homeassistant import data_entry_flow
 from homeassistant.config_entries import ConfigEntryState
@@ -13,23 +13,23 @@ from .common import setup_platform
 
 async def test_unload(hass: HomeAssistant) -> None:
     """Test unload."""
-    entry = await setup_platform(hass, "sensor")
+    entry = await setup_platform(hass)
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_auth_failure(hass: HomeAssistant) -> None:
-    """Test init with an auth failure."""
+    """Test init with an authentication failure."""
     with patch(
         "homeassistant.components.aussie_broadband.config_flow.ConfigFlow.async_step_reauth",
         return_value={"type": data_entry_flow.RESULT_TYPE_FORM},
     ) as mock_async_step_reauth:
-        await setup_platform(hass, "sensor", AuthenticationException())
+        await setup_platform(hass, side_effect=AuthenticationException())
         mock_async_step_reauth.assert_called_once()
 
 
 async def test_net_failure(hass: HomeAssistant) -> None:
-    """Test init with an auth failure."""
-    entry = await setup_platform(hass, "sensor", requests.exceptions.ConnectionError())
+    """Test init with a network failure."""
+    entry = await setup_platform(hass, side_effect=ClientConnectionError())
     assert entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/aussie_broadband/test_sensor.py
+++ b/tests/components/aussie_broadband/test_sensor.py
@@ -39,7 +39,7 @@ async def test_sensor_states(hass):
         "aussiebb.asyncio.AussieBB.telephony_usage", return_value=MOCK_MOBILE_USAGE
     ):
 
-        await setup_platform(hass, SENSOR_DOMAIN)
+        await setup_platform(hass, [SENSOR_DOMAIN])
 
         assert hass.states.get("sensor.nbn_total_usage").state == "54321"
         assert hass.states.get("sensor.nbn_downloaded").state == "50000"

--- a/tests/components/aussie_broadband/test_sensor.py
+++ b/tests/components/aussie_broadband/test_sensor.py
@@ -27,10 +27,6 @@ MOCK_MOBILE_USAGE = {
 }
 
 
-# @patch("aussiebb.asyncio.AussieBB.get_usage", return_value=MOCK_NBN_USAGE)
-# @patch("aussiebb.asyncio.AussieBB.telephony_usage", return_value=MOCK_MOBILE_USAGE)
-
-
 async def test_sensor_states(hass):
     """Tests that the sensors are correct."""
     with patch(

--- a/tests/components/aussie_broadband/test_sensor.py
+++ b/tests/components/aussie_broadband/test_sensor.py
@@ -5,7 +5,7 @@ from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 
 from .common import setup_platform
 
-MOCK_USAGE = {
+MOCK_NBN_USAGE = {
     "usedMb": 54321,
     "downloadedMb": 50000,
     "uploadedMb": 4321,
@@ -13,14 +13,43 @@ MOCK_USAGE = {
     "daysRemaining": 25,
 }
 
+MOCK_MOBILE_USAGE = {
+    "national": {"calls": 1, "cost": 0},
+    "mobile": {"calls": 2, "cost": 0},
+    "international": {"calls": 3, "cost": 0},
+    "sms": {"calls": 4, "cost": 0},
+    "internet": {"kbytes": 512, "cost": 0},
+    "voicemail": {"calls": 6, "cost": 0},
+    "other": {"calls": 7, "cost": 0},
+    "daysTotal": 31,
+    "daysRemaining": 30,
+    "historical": [],
+}
 
-@patch("aussiebb.AussieBB.get_usage", return_value=MOCK_USAGE)
-async def test_sensor_states(mock_get_services, hass):
+
+# @patch("aussiebb.asyncio.AussieBB.get_usage", return_value=MOCK_NBN_USAGE)
+# @patch("aussiebb.asyncio.AussieBB.telephony_usage", return_value=MOCK_MOBILE_USAGE)
+
+
+async def test_sensor_states(hass):
     """Tests that the sensors are correct."""
-    await setup_platform(hass, SENSOR_DOMAIN)
+    with patch(
+        "aussiebb.asyncio.AussieBB.get_usage", return_value=MOCK_NBN_USAGE
+    ), patch(
+        "aussiebb.asyncio.AussieBB.telephony_usage", return_value=MOCK_MOBILE_USAGE
+    ):
 
-    assert hass.states.get("sensor.total_usage").state == "54321"
-    assert hass.states.get("sensor.downloaded").state == "50000"
-    assert hass.states.get("sensor.uploaded").state == "4321"
-    assert hass.states.get("sensor.billing_cycle_length").state == "28"
-    assert hass.states.get("sensor.billing_cycle_remaining").state == "25"
+        await setup_platform(hass, SENSOR_DOMAIN)
+
+        assert hass.states.get("sensor.nbn_total_usage").state == "54321"
+        assert hass.states.get("sensor.nbn_downloaded").state == "50000"
+        assert hass.states.get("sensor.nbn_uploaded").state == "4321"
+        assert hass.states.get("sensor.nbn_billing_cycle_length").state == "28"
+        assert hass.states.get("sensor.nbn_billing_cycle_remaining").state == "25"
+
+        assert hass.states.get("sensor.mobile_national_calls").state == "1"
+        assert hass.states.get("sensor.mobile_mobile_calls").state == "2"
+        assert hass.states.get("sensor.mobile_sms_sent").state == "4"
+        assert hass.states.get("sensor.mobile_data_usage").state == "512"
+        assert hass.states.get("sensor.nbn_billing_cycle_length").state == "31"
+        assert hass.states.get("sensor.nbn_billing_cycle_remaining").state == "30"

--- a/tests/components/aussie_broadband/test_sensor.py
+++ b/tests/components/aussie_broadband/test_sensor.py
@@ -27,13 +27,9 @@ MOCK_MOBILE_USAGE = {
 }
 
 
-async def test_sensor_states(hass):
+async def test_nbn_sensor_states(hass):
     """Tests that the sensors are correct."""
-    with patch(
-        "aussiebb.asyncio.AussieBB.get_usage", return_value=MOCK_NBN_USAGE
-    ), patch(
-        "aussiebb.asyncio.AussieBB.telephony_usage", return_value=MOCK_MOBILE_USAGE
-    ):
+    with patch("aussiebb.asyncio.AussieBB.get_usage", return_value=MOCK_NBN_USAGE):
 
         await setup_platform(hass, [SENSOR_DOMAIN])
 
@@ -42,6 +38,13 @@ async def test_sensor_states(hass):
         assert hass.states.get("sensor.nbn_uploaded").state == "4321"
         assert hass.states.get("sensor.nbn_billing_cycle_length").state == "28"
         assert hass.states.get("sensor.nbn_billing_cycle_remaining").state == "25"
+
+
+async def test_phone_sensor_states(hass):
+    """Tests that the sensors are correct."""
+    with patch("aussiebb.asyncio.AussieBB.get_usage", return_value=MOCK_MOBILE_USAGE):
+
+        await setup_platform(hass, [SENSOR_DOMAIN])
 
         assert hass.states.get("sensor.mobile_national_calls").state == "1"
         assert hass.states.get("sensor.mobile_mobile_calls").state == "2"

--- a/tests/components/aussie_broadband/test_sensor.py
+++ b/tests/components/aussie_broadband/test_sensor.py
@@ -51,5 +51,5 @@ async def test_sensor_states(hass):
         assert hass.states.get("sensor.mobile_mobile_calls").state == "2"
         assert hass.states.get("sensor.mobile_sms_sent").state == "4"
         assert hass.states.get("sensor.mobile_data_usage").state == "512"
-        assert hass.states.get("sensor.nbn_billing_cycle_length").state == "31"
-        assert hass.states.get("sensor.nbn_billing_cycle_remaining").state == "30"
+        assert hass.states.get("sensor.mobile_billing_cycle_length").state == "31"
+        assert hass.states.get("sensor.mobile_billing_cycle_remaining").state == "30"


### PR DESCRIPTION
This is my proposed changes, and given there has been no more action on the base PR I am proposing we merge in into the same PR.

Changes:

1. Uses pyaussiebb's asyncio/aiohttp version
2. Supports mobile phones
3. A single configuration supports multiple services.
4. Services can be changed using "configure"
5. Update interval can be changed using "configure"
6. Sensor names prefixed with the service "name" which is just NBN/Mobile.
7. Tests to cover everything new